### PR TITLE
Handle Mercado Pago OAuth state and token callbacks

### DIFF
--- a/src/app/api/mercadopago/connect/route.ts
+++ b/src/app/api/mercadopago/connect/route.ts
@@ -1,43 +1,47 @@
 import { auth } from '@/auth';
 import { NextRequest, NextResponse } from 'next/server';
-
 import { updateMercadoPagoTokens } from '@/app/actions/userActions';
-import { getAuthorizationUrl, exchangeCodeForToken } from '@/lib/mercadopago';
+import {
+  getAuthorizationUrl,
+  exchangeCodeForToken,
+} from '@/lib/mercadopago';
 
 export async function GET(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return new Response('Unauthorized', { status: 401 });
-  }
-
-  // NUEVA SECCIÓN: Manejar callback de MercadoPago
   const searchParams = request.nextUrl.searchParams;
   const code = searchParams.get('code');
-  
-  if (code) {
-    // Es un callback - procesar el código
-    try {
-      const tokenData = await exchangeCodeForToken(code);
+  const state = searchParams.get('state');
 
-      if (!tokenData.access_token) {
-        throw new Error('No access token received from MercadoPago');
+  if (code) {
+    try {
+      if (!state) {
+        throw new Error('Missing state parameter');
       }
+      const tokenData = await exchangeCodeForToken(code);
       await updateMercadoPagoTokens(
-        session.user.id,
+        state,
         tokenData.access_token,
         tokenData.refresh_token,
         tokenData.user_id?.toString(),
       );
 
-      return NextResponse.redirect(new URL('/members/edit/photos?success=connected', request.url));
+      return NextResponse.redirect(
+        new URL('/members/edit/photos?success=connected', request.url),
+      );
     } catch (error) {
       console.error('MercadoPago callback error:', error);
-      return NextResponse.redirect(new URL('/members/edit/photos?error=connection_failed', request.url));
+      return NextResponse.redirect(
+        new URL('/members/edit/photos?error=connection_failed', request.url),
+      );
     }
   }
 
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+
   try {
-    const url = getAuthorizationUrl();
+    const url = getAuthorizationUrl(session.user.id);
     return NextResponse.json({ url });
   } catch (error) {
     console.error('Error generating authorization URL:', error);

--- a/src/app/api/mp/connect/route.ts
+++ b/src/app/api/mp/connect/route.ts
@@ -1,70 +1,47 @@
 import { auth } from '@/auth';
 import { NextRequest, NextResponse } from 'next/server';
-import { MercadoPagoConfig, OAuth } from 'mercadopago';
-import { updateMercadoPagoTokens } from '@/app/actions/userActions'; // Nueva import
-
-// Configurar MercadoPago
-const mercadopago = new MercadoPagoConfig({
-  accessToken: process.env.MP_ACCESS_TOKEN!
-});
+import { updateMercadoPagoTokens } from '@/app/actions/userActions';
+import {
+  getAuthorizationUrl,
+  exchangeCodeForToken,
+} from '@/lib/mercadopago';
 
 export async function GET(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return new Response('Unauthorized', { status: 401 });
-  }
-
-  // NUEVA SECCIÓN: Manejar callback de MercadoPago
   const searchParams = request.nextUrl.searchParams;
   const code = searchParams.get('code');
-  
+  const state = searchParams.get('state');
+
   if (code) {
-    // Es un callback - procesar el código
     try {
-      const tokenResponse = await fetch('https://api.mercadopago.com/oauth/token', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Accept': 'application/json'
-        },
-        body: new URLSearchParams({
-          grant_type: 'authorization_code',
-          client_id: process.env.NEXT_PUBLIC_MP_CLIENT_ID!,
-          client_secret: process.env.MP_CLIENT_SECRET!,
-          code: code,
-          redirect_uri: process.env.MP_REDIRECT_URI!
-        })
-      });
-      console.log('Token response:', tokenResponse);
-      if (!tokenResponse.ok) {
-        throw new Error('Failed to exchange code for token');
+      if (!state) {
+        throw new Error('Missing state parameter');
       }
-
-      const tokenData = await tokenResponse.json();
-
+      const tokenData = await exchangeCodeForToken(code);
       await updateMercadoPagoTokens(
-        session.user.id,
+        state,
         tokenData.access_token,
         tokenData.refresh_token,
         tokenData.user_id?.toString()
       );
 
-      return NextResponse.redirect(new URL('/members/edit/photos?success=connected', request.url));
+      return NextResponse.redirect(
+        new URL('/members/edit/photos?success=connected', request.url)
+      );
     } catch (error) {
       console.error('MercadoPago callback error:', error);
-      return NextResponse.redirect(new URL('/members/edit/photos?error=connection_failed', request.url));
+      return NextResponse.redirect(
+        new URL('/members/edit/photos?error=connection_failed', request.url)
+      );
     }
   }
 
-  // CÓDIGO ORIGINAL: Generar URL de autorización (sin cambios)
-  try {
-    const url = new OAuth(mercadopago).getAuthorizationURL({
-      options: {
-        client_id: process.env.NEXT_PUBLIC_MP_CLIENT_ID!,
-        redirect_uri: process.env.MP_REDIRECT_URI!,
-      },
-    });
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new Response('Unauthorized', { status: 401 });
+  }
 
+  try {
+    const url = getAuthorizationUrl(session.user.id);
     return NextResponse.json({ url });
   } catch (error) {
     console.error('Error generating authorization URL:', error);

--- a/src/app/members/[userId]/page.tsx
+++ b/src/app/members/[userId]/page.tsx
@@ -4,9 +4,6 @@ import { notFound } from 'next/navigation';
 import React from 'react'
 
 export default async function MemberDetailedPage({params} : {params : {userId : string}}) {
-    const {userId} = await params;
-
-
   const member = await getMemberByUserId(params.userId);
   
   if(!member) return notFound();

--- a/src/lib/mercadopago.ts
+++ b/src/lib/mercadopago.ts
@@ -6,11 +6,12 @@ export const mercadopago = new MercadoPagoConfig({
 });
 
 // Generate authorization URL for OAuth flow
-export function getAuthorizationUrl() {
+export function getAuthorizationUrl(state: string) {
   return new OAuth(mercadopago).getAuthorizationURL({
     options: {
       client_id: process.env.NEXT_PUBLIC_MP_CLIENT_ID!,
       redirect_uri: process.env.MP_REDIRECT_URI!,
+      state,
     },
   });
 }


### PR DESCRIPTION
## Summary
- accept state parameter in Mercado Pago authorization URL helper and forward it to OAuth
- update Mercado Pago connect API routes to read code/state query params, update tokens, and generate stateful auth URLs
- clean up unused variable in member page to satisfy lint

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6897b4fff0c4832aab6369cec1b1002f